### PR TITLE
Added a better and proper linter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
+import fossyl from './packages/eslint-plugin/dist/index.js';
 
 export default [
   {
@@ -15,13 +16,14 @@ export default [
     },
     plugins: {
       '@typescript-eslint': tseslint,
+      fossyl,
     },
     rules: {
-      // Other useful strict rules
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
+      'fossyl/no-repo-import-outside-service': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -1,0 +1,100 @@
+# eslint-plugin-fossyl - Contributor Guide
+
+**ESLint plugin for Fossyl projects - architecture enforcement and route quality rules**
+
+> **AI Collaboration:** This package is in the **Green Zone** - contributions welcome. See `/CONTRIBUTING.md` for guidelines. Do not modify `@fossyl/core`.
+
+## Source Structure
+
+```
+src/
+├── index.ts                          # Plugin entry - exports rules and configs
+├── rules/
+│   ├── no-repo-import-outside-service.ts  # Architecture: .repo imports only in .service
+│   ├── no-duplicate-routes.ts             # Route quality: no duplicate METHOD+PATH
+│   ├── path-prefix-convention.ts          # Route quality: paths must start with /api/
+│   ├── consistent-naming.ts               # Route quality: file name matches prefix
+│   └── no-mixed-prefixes.ts              # Route quality: single prefix per file
+└── utils/
+    ├── rule-factory.ts              # createRule from @typescript-eslint/utils
+    └── route-collector.ts           # Cross-file route analysis (singleton store)
+```
+
+## Available Configs
+
+| Config | Rules Included | Severity |
+|--------|---------------|----------|
+| `recommended` | no-repo-import-outside-service, no-duplicate-routes | error |
+| `all` | All 5 rules | error / warn |
+| `architecture-enforcement` | no-repo-import-outside-service | error |
+| `route-quality` | no-duplicate-routes, path-prefix-convention, consistent-naming, no-mixed-prefixes | error / warn |
+
+## Usage
+
+```typescript
+// eslint.config.js
+import fossyl from 'eslint-plugin-fossyl';
+
+export default [
+  {
+    plugins: { fossyl },
+    rules: {
+      'fossyl/no-repo-import-outside-service': 'error',
+      'fossyl/no-duplicate-routes': 'error',
+    },
+  },
+];
+
+// Or use a pre-built config:
+export default [
+  {
+    plugins: { fossyl },
+    ...fossyl.configs.recommended,
+  },
+];
+```
+
+## Rule Details
+
+### no-repo-import-outside-service
+Prevents importing `.repo` files anywhere except `.service` files. Enforces the architectural boundary between repositories (data access) and services (business logic).
+
+**Options:**
+- `allowImports` (string[]): Additional import paths allowed to import .repo files
+
+### no-duplicate-routes
+Prevents the same METHOD + PATH from being defined twice across the project.
+
+### path-prefix-convention
+Enforces that route paths start with a required prefix (default: `/api/`).
+
+**Options:**
+- `prefixes` (string[]): Allowed prefixes (default: `['/api/']`)
+
+### consistent-naming
+Route files should be named consistently with their `createRouter()` prefix.
+
+### no-mixed-prefixes
+All routes in a single file must share the same `createRouter()` base prefix.
+
+## Route Collector
+
+The `route-collector.ts` module uses a singleton store (`routeStore`) to accumulate route information across files during a single ESLint run. This enables cross-file analysis for `no-duplicate-routes`.
+
+## Development Commands
+
+```bash
+pnpm build             # Build with tsup (cjs + esm + dts)
+pnpm typecheck         # Check types with tsc --noEmit
+pnpm test              # Run vitest tests
+pnpm dev               # Watch mode
+```
+
+## Contribution Guidelines
+
+When adding rules:
+- Use the `createRule` factory from `utils/rule-factory.ts`
+- Follow the type-safety patterns from existing rules
+- Add tests for valid and invalid cases
+- Update the plugin's `configs` in `index.ts`
+- Register rules in the plugin's `rules` export

--- a/packages/eslint-plugin/AGENTS.md
+++ b/packages/eslint-plugin/AGENTS.md
@@ -22,25 +22,25 @@ src/
 
 ## Available Configs
 
-| Config | Rules Included | Severity |
-|--------|---------------|----------|
-| `recommended` | no-repo-import-outside-service, no-duplicate-routes | error |
-| `all` | All 5 rules | error / warn |
-| `architecture-enforcement` | no-repo-import-outside-service | error |
-| `route-quality` | no-duplicate-routes, path-prefix-convention, consistent-naming, no-mixed-prefixes | error / warn |
+| Config                     | Rules Included                                                                    | Severity     |
+| -------------------------- | --------------------------------------------------------------------------------- | ------------ |
+| `recommended`              | no-repo-import-outside-service, no-duplicate-routes                               | error        |
+| `all`                      | All 5 rules                                                                       | error / warn |
+| `architecture-enforcement` | no-repo-import-outside-service                                                    | error        |
+| `route-quality`            | no-duplicate-routes, path-prefix-convention, consistent-naming, no-mixed-prefixes | error / warn |
 
 ## Usage
 
 ```typescript
 // eslint.config.js
-import fossyl from 'eslint-plugin-fossyl';
+import fossyl from "eslint-plugin-fossyl";
 
 export default [
   {
     plugins: { fossyl },
     rules: {
-      'fossyl/no-repo-import-outside-service': 'error',
-      'fossyl/no-duplicate-routes': 'error',
+      "fossyl/no-repo-import-outside-service": "error",
+      "fossyl/no-duplicate-routes": "error",
     },
   },
 ];
@@ -57,29 +57,109 @@ export default [
 ## Rule Details
 
 ### no-repo-import-outside-service
+
 Prevents importing `.repo` files anywhere except `.service` files. Enforces the architectural boundary between repositories (data access) and services (business logic).
 
 **Options:**
+
 - `allowImports` (string[]): Additional import paths allowed to import .repo files
 
 ### no-duplicate-routes
+
 Prevents the same METHOD + PATH from being defined twice across the project.
 
 ### path-prefix-convention
+
 Enforces that route paths start with a required prefix (default: `/api/`).
 
 **Options:**
+
 - `prefixes` (string[]): Allowed prefixes (default: `['/api/']`)
 
 ### consistent-naming
+
 Route files should be named consistently with their `createRouter()` prefix.
 
 ### no-mixed-prefixes
+
 All routes in a single file must share the same `createRouter()` base prefix.
 
 ## Route Collector
 
 The `route-collector.ts` module uses a singleton store (`routeStore`) to accumulate route information across files during a single ESLint run. This enables cross-file analysis for `no-duplicate-routes`.
+
+## Chain API Handler Shapes
+
+The `@fossyl/core` chain API uses **curried handler functions**. Each middleware layer (params, auth, body) is a synchronous function that returns the next layer. Only the innermost `() => Promise<Response>` is `async`.
+
+The structural pattern is always:
+
+```
+(params?) => (auth?) => (body?) => async () => Promise<Response>
+```
+
+Each layer is **present or skipped** based on the chain. `params` is present when any of these are configured: a `:param` in the path, `.query()`, or `.paginate()`. Auth is present when `.authenticator()` is in the chain. Body is present when `.validator()` is in the chain.
+
+### Handler signature by chain combination
+
+| Chain Layers         | Handler Signature                                     |
+| -------------------- | ----------------------------------------------------- |
+| none                 | `async () => ({...})`                                 |
+| params only          | `(params) => async () => ({...})`                     |
+| auth only            | `(auth) => async () => ({...})`                       |
+| params + auth        | `(params) => (auth) => async () => ({...})`           |
+| body only            | `(body) => async () => ({...})`                       |
+| params + body        | `(params) => (body) => async () => ({...})`           |
+| auth + body          | `(auth) => (body) => async () => ({...})`             |
+| params + auth + body | `(params) => (auth) => (body) => async () => ({...})` |
+
+### Rules
+
+1. **Only the final `() => Promise<Response>` is `async`** — all outer curry layers return synchronously.
+2. **`params` is present when** the path has any `:param`, or `.query()` is chained, or `.paginate()` is chained.
+3. **No `authenticator` = no auth layer** — the curry skips from params to body (or to the final response).
+4. **No `validator` = no body layer** — the curry skips from auth to the final response.
+
+### Examples
+
+```typescript
+// Full stack: params + auth + body
+createEndpoint("/api/todos/:id")
+  .authenticator(authenticator)
+  .validator(validator)
+  .put((params) => (auth) => (body) => async () => ({
+    typeName: "Todo",
+    ...body,
+  }));
+
+// Params + auth only (no body)
+createEndpoint("/api/todos/:id")
+  .authenticator(authenticator)
+  .get((params) => (auth) => async () => ({
+    typeName: "Todo",
+    id: params.url.id,
+  }));
+
+// No params, no auth, no body
+createEndpoint("/api/health").get(async () => ({ typeName: "Health", status: "ok" }));
+
+// Auth + body only (no params)
+createEndpoint("/api/todos")
+  .authenticator(authenticator)
+  .validator(validator)
+  .post((auth) => (body) => async () => ({
+    typeName: "Todo",
+    ...body,
+  }));
+
+// Params only (pagination)
+createEndpoint("/api/todos")
+  .paginate({ defaultPageSize: 20 })
+  .get((params) => async () => ({
+    data: [],
+    pagination: { page: 1, pageSize: 20, hasMore: false },
+  }));
+```
 
 ## Development Commands
 
@@ -93,6 +173,7 @@ pnpm dev               # Watch mode
 ## Contribution Guidelines
 
 When adding rules:
+
 - Use the `createRule` factory from `utils/rule-factory.ts`
 - Follow the type-safety patterns from existing rules
 - Add tests for valid and invalid cases

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "eslint-plugin-fossyl",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "ESLint plugin for Fossyl projects - architecture enforcement and route quality rules",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "fossyl",
+    "eslint",
+    "eslint-plugin",
+    "eslintplugin",
+    "architecture",
+    "linting",
+    "typescript"
+  ],
+  "author": "YoyoSaur",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/YoyoSaur/fossyl.git",
+    "directory": "packages/eslint-plugin"
+  },
+  "homepage": "https://github.com/YoyoSaur/fossyl#readme",
+  "bugs": {
+    "url": "https://github.com/YoyoSaur/fossyl/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,47 @@
+import noRepoImportOutsideService from './rules/no-repo-import-outside-service';
+import noDuplicateRoutes from './rules/no-duplicate-routes';
+import pathPrefixConvention from './rules/path-prefix-convention';
+import consistentNaming from './rules/consistent-naming';
+import noMixedPrefixes from './rules/no-mixed-prefixes';
+
+const plugin = {
+  rules: {
+    'no-repo-import-outside-service': noRepoImportOutsideService,
+    'no-duplicate-routes': noDuplicateRoutes,
+    'path-prefix-convention': pathPrefixConvention,
+    'consistent-naming': consistentNaming,
+    'no-mixed-prefixes': noMixedPrefixes,
+  },
+  configs: {
+    recommended: {
+      rules: {
+        'fossyl/no-repo-import-outside-service': 'error',
+        'fossyl/no-duplicate-routes': 'error',
+      },
+    },
+    all: {
+      rules: {
+        'fossyl/no-repo-import-outside-service': 'error',
+        'fossyl/no-duplicate-routes': 'error',
+        'fossyl/path-prefix-convention': 'warn',
+        'fossyl/consistent-naming': 'warn',
+        'fossyl/no-mixed-prefixes': 'warn',
+      },
+    },
+    'route-quality': {
+      rules: {
+        'fossyl/no-duplicate-routes': 'error',
+        'fossyl/path-prefix-convention': 'warn',
+        'fossyl/consistent-naming': 'warn',
+        'fossyl/no-mixed-prefixes': 'warn',
+      },
+    },
+    'architecture-enforcement': {
+      rules: {
+        'fossyl/no-repo-import-outside-service': 'error',
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/packages/eslint-plugin/src/rules/consistent-naming.ts
+++ b/packages/eslint-plugin/src/rules/consistent-naming.ts
@@ -1,0 +1,58 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/rule-factory';
+import { getCreateRouterPrefix, getRelativeFilePath } from '../utils/route-collector';
+import path from 'node:path';
+
+export type MessageIds = 'namingMismatch';
+
+export type Options = [];
+
+export default createRule<Options, MessageIds>({
+  name: 'consistent-naming',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Route files should have a name consistent with their path prefix (e.g., users.route.ts should use /users prefix).',
+    },
+    schema: [],
+    messages: {
+      namingMismatch:
+        "Route prefix '{{prefix}}' does not match file name '{{fileName}}'. Expected a prefix related to '/{{expectedPrefix}}'.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const filePath = context.filename;
+    const fileName = path.basename(filePath);
+    const fileNameStem = fileName
+      .replace(/\.route\.[a-z]+$/i, '')
+      .replace(/\.[a-z]+$/i, '')
+      .toLowerCase();
+
+    function fileNameMatchesPrefix(prefix: string): boolean {
+      const prefixSegment = prefix.replace(/\/+$/, '').split('/').pop() || '';
+      return prefixSegment.toLowerCase() === fileNameStem;
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        const prefix = getCreateRouterPrefix(node);
+        if (!prefix) return;
+
+        if (!fileNameMatchesPrefix(prefix)) {
+          const relPath = getRelativeFilePath(filePath);
+          context.report({
+            node,
+            messageId: 'namingMismatch',
+            data: {
+              prefix,
+              fileName: relPath,
+              expectedPrefix: fileNameStem,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/integration.test.ts
+++ b/packages/eslint-plugin/src/rules/integration.test.ts
@@ -1,0 +1,125 @@
+import { ESLint } from 'eslint';
+import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { createRequire } from 'node:module';
+import { routeStore } from '../utils/route-collector';
+
+const _require = createRequire(import.meta.url);
+const pluginPath = path.join(process.cwd(), 'dist', 'index.cjs');
+const testAppSrc = path.join(process.cwd(), 'test-app', 'src');
+const parserPath = _require.resolve('@typescript-eslint/parser');
+
+function createIntegrationConfig(): string {
+  return [
+    'const fossyl = require("' + pluginPath.replace(/\\/g, '/') + '").default;',
+    'const tsparser = require("' + parserPath.replace(/\\/g, '/') + '");',
+    'module.exports = [{',
+    '  files: ["**/*.ts"],',
+    '  plugins: { fossyl },',
+    '  rules: {',
+    '    "fossyl/no-repo-import-outside-service": "error",',
+    '    "fossyl/no-duplicate-routes": "error",',
+    '    "fossyl/path-prefix-convention": ["warn", { "prefixes": ["/api/"] }],',
+    '    "fossyl/consistent-naming": "warn",',
+    '    "fossyl/no-mixed-prefixes": "warn",',
+    '  },',
+    '  languageOptions: {',
+    '    parser: tsparser,',
+    '    parserOptions: { ecmaVersion: 2022, sourceType: "module" },',
+    '  },',
+    '}];',
+  ].join('\n');
+}
+
+function copyDirSync(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSync(s, d);
+    } else {
+      fs.copyFileSync(s, d);
+    }
+  }
+}
+
+describe('test-app integration', () => {
+  beforeEach(() => {
+    routeStore.reset();
+  });
+
+  it('should produce expected fossyl violations across all test-app files', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fossyl-integration-'));
+    try {
+      const tmpSrc = path.join(tmpDir, 'src');
+      copyDirSync(testAppSrc, tmpSrc);
+      fs.writeFileSync(path.join(tmpDir, 'eslint.config.cjs'), createIntegrationConfig());
+
+      const allFiles: string[] = [];
+      function collectFiles(dir: string): void {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            collectFiles(full);
+          } else if (entry.name.endsWith('.ts')) {
+            allFiles.push(path.relative(tmpDir, full));
+          }
+        }
+      }
+      collectFiles(tmpSrc);
+      allFiles.sort((a, b) => {
+        const aIsFeat = a.startsWith('src/features/');
+        const bIsFeat = b.startsWith('src/features/');
+        if (aIsFeat && !bIsFeat) return -1;
+        if (!aIsFeat && bIsFeat) return 1;
+        return a.localeCompare(b);
+      });
+
+      const eslint = new ESLint({ cwd: tmpDir });
+      const results = await eslint.lintFiles(allFiles);
+
+      const violations: Record<string, string[]> = {};
+      for (const result of results) {
+        const relPath = path.relative(tmpSrc, result.filePath);
+        violations[relPath] = result.messages
+          .filter((m) => m.ruleId && m.ruleId.startsWith('fossyl/'))
+          .map((m) => m.ruleId!);
+      }
+
+      const expected: Record<string, number> = {
+        // Valid files (zero fossyl violations expected)
+        'features/todos/repo/todos.repo.ts': 0,
+        'features/todos/routes/todos.route.ts': 0,
+        'features/todos/services/todos.service.ts': 0,
+        'features/users/repo/users.repo.ts': 0,
+        'features/users/routes/users.route.ts': 0,
+        'features/users/services/users.service.ts': 0,
+        'features/users/validators/users.validators.ts': 0,
+        'auth.ts': 0,
+        'index.ts': 1,
+        // Violation files
+        'violations/duplicate-routes.ts': 2,
+        'violations/mixed-prefixes.route.ts': 3,
+        'violations/no-prefix.route.ts': 3,
+        'violations/plain-file-imports-repo.ts': 2,
+        'violations/route-imports-repo.ts': 2,
+        'violations/things.route.ts': 1,
+        'violations/things.service.ts': 1,
+        'violations/validator-imports-repo.ts': 1,
+      };
+
+      for (const [file, expectedCount] of Object.entries(expected)) {
+        const actual = violations[file] ?? [];
+        expect(
+          actual.length,
+          `Expected ${expectedCount} fossyl violations in ${file}, got ${actual.length}: [${actual.join(', ')}]`,
+        ).toBe(expectedCount);
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/eslint-plugin/src/rules/integration.test.ts
+++ b/packages/eslint-plugin/src/rules/integration.test.ts
@@ -1,36 +1,36 @@
-import { ESLint } from 'eslint';
-import { describe, it, expect, beforeEach } from 'vitest';
-import path from 'node:path';
-import fs from 'node:fs';
-import os from 'node:os';
-import { createRequire } from 'node:module';
-import { routeStore } from '../utils/route-collector';
+import { ESLint } from "eslint";
+import { describe, it, expect, beforeEach } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { createRequire } from "node:module";
+import { routeStore } from "../utils/route-collector";
 
 const _require = createRequire(import.meta.url);
-const pluginPath = path.join(process.cwd(), 'dist', 'index.cjs');
-const testAppSrc = path.join(process.cwd(), 'test-app', 'src');
-const parserPath = _require.resolve('@typescript-eslint/parser');
+const pluginPath = path.join(process.cwd(), "dist", "index.cjs");
+const testAppSrc = path.join(process.cwd(), "test-app", "src");
+const parserPath = _require.resolve("@typescript-eslint/parser");
 
 function createIntegrationConfig(): string {
   return [
-    'const fossyl = require("' + pluginPath.replace(/\\/g, '/') + '").default;',
-    'const tsparser = require("' + parserPath.replace(/\\/g, '/') + '");',
-    'module.exports = [{',
+    'const fossyl = require("' + pluginPath.replace(/\\/g, "/") + '").default;',
+    'const tsparser = require("' + parserPath.replace(/\\/g, "/") + '");',
+    "module.exports = [{",
     '  files: ["**/*.ts"],',
-    '  plugins: { fossyl },',
-    '  rules: {',
+    "  plugins: { fossyl },",
+    "  rules: {",
     '    "fossyl/no-repo-import-outside-service": "error",',
     '    "fossyl/no-duplicate-routes": "error",',
     '    "fossyl/path-prefix-convention": ["warn", { "prefixes": ["/api/"] }],',
     '    "fossyl/consistent-naming": "warn",',
     '    "fossyl/no-mixed-prefixes": "warn",',
-    '  },',
-    '  languageOptions: {',
-    '    parser: tsparser,',
+    "  },",
+    "  languageOptions: {",
+    "    parser: tsparser,",
     '    parserOptions: { ecmaVersion: 2022, sourceType: "module" },',
-    '  },',
-    '}];',
-  ].join('\n');
+    "  },",
+    "}];",
+  ].join("\n");
 }
 
 function copyDirSync(src: string, dest: string): void {
@@ -46,17 +46,17 @@ function copyDirSync(src: string, dest: string): void {
   }
 }
 
-describe('test-app integration', () => {
+describe("test-app integration", () => {
   beforeEach(() => {
     routeStore.reset();
   });
 
-  it('should produce expected fossyl violations across all test-app files', async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fossyl-integration-'));
+  it("should produce expected fossyl violations across all test-app files", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fossyl-integration-"));
     try {
-      const tmpSrc = path.join(tmpDir, 'src');
+      const tmpSrc = path.join(tmpDir, "src");
       copyDirSync(testAppSrc, tmpSrc);
-      fs.writeFileSync(path.join(tmpDir, 'eslint.config.cjs'), createIntegrationConfig());
+      fs.writeFileSync(path.join(tmpDir, "eslint.config.cjs"), createIntegrationConfig());
 
       const allFiles: string[] = [];
       function collectFiles(dir: string): void {
@@ -64,15 +64,15 @@ describe('test-app integration', () => {
           const full = path.join(dir, entry.name);
           if (entry.isDirectory()) {
             collectFiles(full);
-          } else if (entry.name.endsWith('.ts')) {
+          } else if (entry.name.endsWith(".ts")) {
             allFiles.push(path.relative(tmpDir, full));
           }
         }
       }
       collectFiles(tmpSrc);
       allFiles.sort((a, b) => {
-        const aIsFeat = a.startsWith('src/features/');
-        const bIsFeat = b.startsWith('src/features/');
+        const aIsFeat = a.startsWith("src/features/");
+        const bIsFeat = b.startsWith("src/features/");
         if (aIsFeat && !bIsFeat) return -1;
         if (!aIsFeat && bIsFeat) return 1;
         return a.localeCompare(b);
@@ -85,37 +85,37 @@ describe('test-app integration', () => {
       for (const result of results) {
         const relPath = path.relative(tmpSrc, result.filePath);
         violations[relPath] = result.messages
-          .filter((m) => m.ruleId && m.ruleId.startsWith('fossyl/'))
+          .filter((m) => m.ruleId && m.ruleId.startsWith("fossyl/"))
           .map((m) => m.ruleId!);
       }
 
       const expected: Record<string, number> = {
         // Valid files (zero fossyl violations expected)
-        'features/todos/repo/todos.repo.ts': 0,
-        'features/todos/routes/todos.route.ts': 0,
-        'features/todos/services/todos.service.ts': 0,
-        'features/users/repo/users.repo.ts': 0,
-        'features/users/routes/users.route.ts': 0,
-        'features/users/services/users.service.ts': 0,
-        'features/users/validators/users.validators.ts': 0,
-        'auth.ts': 0,
-        'index.ts': 1,
+        "features/todos/repo/todos.repo.ts": 0,
+        "features/todos/routes/todos.route.ts": 0,
+        "features/todos/services/todos.service.ts": 0,
+        "features/users/repo/users.repo.ts": 0,
+        "features/users/routes/users.route.ts": 0,
+        "features/users/services/users.service.ts": 0,
+        "features/users/validators/users.validators.ts": 0,
+        "auth.ts": 0,
+        "index.ts": 1,
         // Violation files
-        'violations/duplicate-routes.ts': 2,
-        'violations/mixed-prefixes.route.ts': 3,
-        'violations/no-prefix.route.ts': 3,
-        'violations/plain-file-imports-repo.ts': 2,
-        'violations/route-imports-repo.ts': 2,
-        'violations/things.route.ts': 1,
-        'violations/things.service.ts': 1,
-        'violations/validator-imports-repo.ts': 1,
+        "violations/duplicate-routes.ts": 2,
+        "violations/mixed-prefixes.route.ts": 4,
+        "violations/no-prefix.route.ts": 3,
+        "violations/plain-file-imports-repo.ts": 2,
+        "violations/route-imports-repo.ts": 2,
+        "violations/things.route.ts": 1,
+        "violations/things.service.ts": 1,
+        "violations/validator-imports-repo.ts": 1,
       };
 
       for (const [file, expectedCount] of Object.entries(expected)) {
         const actual = violations[file] ?? [];
         expect(
           actual.length,
-          `Expected ${expectedCount} fossyl violations in ${file}, got ${actual.length}: [${actual.join(', ')}]`,
+          `Expected ${expectedCount} fossyl violations in ${file}, got ${actual.length}: [${actual.join(", ")}]`
         ).toBe(expectedCount);
       }
     } finally {

--- a/packages/eslint-plugin/src/rules/no-duplicate-routes.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-routes.ts
@@ -1,0 +1,87 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/rule-factory';
+import {
+  routeStore,
+  getRouteInfo,
+  getCreateRouterPrefix,
+  getRelativeFilePath,
+} from '../utils/route-collector';
+
+export type MessageIds = 'duplicateRoute' | 'duplicateRouteDetails';
+
+export type Options = [];
+
+export default createRule<Options, MessageIds>({
+  name: 'no-duplicate-routes',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Prevent same METHOD + PATH combination from being defined twice across the project.',
+    },
+    schema: [],
+    messages: {
+      duplicateRoute:
+        "Duplicate route: {{method}} {{path}} already defined at {{otherFile}}:{{otherLine}}.",
+      duplicateRouteDetails:
+        "Duplicate route: {{method}} {{path}} is defined {{count}} times across the project.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const filePath = context.filename;
+    let currentBasePrefix: string | null = null;
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        const prefix = getCreateRouterPrefix(node);
+        if (prefix) {
+          currentBasePrefix = prefix;
+          routeStore.setBasePrefix(filePath, prefix);
+          return;
+        }
+
+        const routeInfo = getRouteInfo(node);
+        if (!routeInfo) return;
+
+        routeStore.addRoute(filePath, {
+          filePath,
+          method: routeInfo.method,
+          fullPath: routeInfo.path,
+          basePrefix: currentBasePrefix,
+          createEndpointNode: routeInfo.node,
+          createEndpointLine: routeInfo.node.loc?.start.line ?? 0,
+        });
+      },
+
+      'Program:exit'(): void {
+        const duplicates = routeStore.findDuplicates();
+
+        for (const dup of duplicates) {
+          const currentOccurrences = dup.occurrences.filter(
+            (o) => o.filePath === filePath,
+          );
+          if (currentOccurrences.length === 0) continue;
+
+          const firstGlobal = dup.occurrences[0];
+
+          for (const occurrence of currentOccurrences) {
+            if (occurrence === firstGlobal) continue;
+
+            const otherRelPath = getRelativeFilePath(firstGlobal.filePath);
+            context.report({
+              node: occurrence.createEndpointNode,
+              messageId: 'duplicateRoute',
+              data: {
+                method: dup.method,
+                path: dup.path,
+                otherFile: otherRelPath,
+                otherLine: String(firstGlobal.createEndpointLine),
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-mixed-prefixes.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-prefixes.ts
@@ -1,0 +1,54 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/rule-factory';
+import { getCreateRouterPrefix } from '../utils/route-collector';
+
+export type MessageIds = 'mixedPrefixes';
+
+export type Options = [];
+
+export default createRule<Options, MessageIds>({
+  name: 'no-mixed-prefixes',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'All routes in one file must share the same base prefix from createRouter().',
+    },
+    schema: [],
+    messages: {
+      mixedPrefixes:
+        "File uses multiple router prefixes. '{{prefix}}' is not the primary prefix '{{primaryPrefix}}'. All routes in one file should share the same base prefix.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const prefixesInFile: { prefix: string; node: TSESTree.CallExpression }[] = [];
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        const prefix = getCreateRouterPrefix(node);
+        if (!prefix) return;
+
+        prefixesInFile.push({ prefix, node });
+      },
+
+      'Program:exit'(): void {
+        if (prefixesInFile.length <= 1) return;
+
+        const primary = prefixesInFile[0].prefix;
+
+        for (let i = 1; i < prefixesInFile.length; i++) {
+          const { prefix, node } = prefixesInFile[i];
+          context.report({
+            node,
+            messageId: 'mixedPrefixes',
+            data: {
+              prefix,
+              primaryPrefix: primary,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-repo-import-outside-service.test.ts
+++ b/packages/eslint-plugin/src/rules/no-repo-import-outside-service.test.ts
@@ -1,0 +1,109 @@
+import { ESLint } from 'eslint';
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+
+function createESLint(tmpDir: string): ESLint {
+  const pluginPath = path.join(process.cwd(), 'dist', 'index.cjs');
+  const config = [
+    'const fossyl = require("' + pluginPath.replace(/\\/g, '/') + '").default;',
+    'module.exports = [{',
+    '  files: ["**/*.ts"],',
+    '  plugins: { fossyl },',
+    '  rules: { "fossyl/no-repo-import-outside-service": "error" },',
+    '  languageOptions: { ecmaVersion: 2020, sourceType: "module" },',
+    '}];',
+  ].join('\n');
+  fs.writeFileSync(path.join(tmpDir, 'eslint.config.cjs'), config);
+  return new ESLint({ cwd: tmpDir });
+}
+
+async function lintCode(code: string, filename: string): Promise<ReturnType<ESLint['lintFiles']>> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fossyl-test-'));
+  try {
+    fs.writeFileSync(path.join(tmpDir, filename), code);
+    const eslint = createESLint(tmpDir);
+    const results = await eslint.lintFiles([filename]);
+    return results;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('no-repo-import-outside-service', () => {
+  it('should allow repo import in service files', async () => {
+    const [result] = await lintCode(
+      'import { repo } from "./repo/user.repo";\n',
+      'user.service.ts',
+    );
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should allow non-repo import in any file', async () => {
+    const [result] = await lintCode('import { z } from "zod";\n', 'user.route.ts');
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should allow service import in route file', async () => {
+    const [result] = await lintCode(
+      'import { svc } from "./services/user.service";\n',
+      'user.route.ts',
+    );
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should allow re-export from repo in service file', async () => {
+    const [result] = await lintCode(
+      'export { repo } from "./repo/index.repo";\n',
+      'index.service.ts',
+    );
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it('should flag cross-boundary repo import in service file', async () => {
+    const [result] = await lintCode(
+      'import { repo } from "./repo/user.repo";\n',
+      'things.service.ts',
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].ruleId).toBe('fossyl/no-repo-import-outside-service');
+    expect(result.messages[0].messageId).toBe('crossBoundaryRepoImport');
+  });
+
+  it('should flag repo import in route file', async () => {
+    const [result] = await lintCode(
+      'import { repo } from "./repo/user.repo";\n',
+      'user.route.ts',
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].ruleId).toBe('fossyl/no-repo-import-outside-service');
+  });
+
+  it('should flag repo import with .ts extension in validator file', async () => {
+    const [result] = await lintCode(
+      'import { repo } from "./repo/user.repo.ts";\n',
+      'user.validator.ts',
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].ruleId).toBe('fossyl/no-repo-import-outside-service');
+  });
+
+  it('should flag repo re-export in non-service file', async () => {
+    const [result] = await lintCode(
+      'export { repo } from "./repo/user.repo";\n',
+      'index.ts',
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].ruleId).toBe('fossyl/no-repo-import-outside-service');
+  });
+
+  it('should flag export * from repo in non-service file', async () => {
+    const [result] = await lintCode(
+      'export * from "./repo/user.repo";\n',
+      'index.ts',
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].ruleId).toBe('fossyl/no-repo-import-outside-service');
+  });
+});

--- a/packages/eslint-plugin/src/rules/no-repo-import-outside-service.ts
+++ b/packages/eslint-plugin/src/rules/no-repo-import-outside-service.ts
@@ -1,0 +1,138 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/rule-factory';
+import path from 'node:path';
+
+const REPO_IMPORT_PATTERN = /[/\\][^/\\]*\.repo(\.[a-z]+)?$/;
+const SERVICE_FILE_PATTERN = /[/\\][^/\\]*\.service(\.[a-z]+)?$/;
+const REPO_IMPORT_NO_PATH_PATTERN = /\.repo(\.[a-z]+)?$/;
+const STEM_EXTRACT_REPO = /([^/\\]+)\.repo(\.[a-z]+)?$/;
+
+export type MessageIds = 'repoImportOutsideService' | 'crossBoundaryRepoImport';
+
+export type Options = [
+  {
+    allowImports?: string[];
+  },
+];
+
+export default createRule<Options, MessageIds>({
+  name: 'no-repo-import-outside-service',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Repository files (*.repo) can only be imported in service files (*.service).',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowImports: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Additional import paths that are allowed to import .repo files.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      repoImportOutsideService:
+        "Repository files (*.repo) can only be imported in service files (*.service). Import '{{importPath}}' in '{{fileName}}' violates the service layer boundary.",
+      crossBoundaryRepoImport:
+        "Service file imports repository from a different service boundary. Expected a repository matching '{{expectedStem}}' but imported '{{actualStem}}' from '{{importPath}}'.",
+    },
+  },
+  defaultOptions: [{ allowImports: [] }],
+  create(context, [options]) {
+    const fileName = context.filename;
+    const isServiceFile = SERVICE_FILE_PATTERN.test(fileName);
+    const serviceStem = isServiceFile
+      ? path.basename(fileName).replace(/\.service\.[a-z]+$/i, '').replace(/\.service$/i, '')
+      : null;
+
+    function getRepoStem(sourceValue: string): string | null {
+      const match = sourceValue.match(STEM_EXTRACT_REPO);
+      return match ? match[1] : null;
+    }
+
+    function isRepoImport(sourceValue: string): boolean {
+      if (REPO_IMPORT_PATTERN.test(sourceValue)) {
+        return true;
+      }
+      if (REPO_IMPORT_NO_PATH_PATTERN.test(sourceValue) && sourceValue.includes('/')) {
+        return false;
+      }
+      if (REPO_IMPORT_NO_PATH_PATTERN.test(sourceValue)) {
+        return true;
+      }
+      return false;
+    }
+
+    function isAllowedImport(sourceValue: string): boolean {
+      return options.allowImports?.some((allowed) => sourceValue.startsWith(allowed)) ?? false;
+    }
+
+    function checkImport(sourceValue: string, node: TSESTree.Node): void {
+      if (isAllowedImport(sourceValue)) return;
+      if (!isRepoImport(sourceValue)) return;
+
+      if (isServiceFile && serviceStem) {
+        const repoStem = getRepoStem(sourceValue);
+        if (repoStem && repoStem.toLowerCase() !== serviceStem.toLowerCase()) {
+          context.report({
+            node,
+            messageId: 'crossBoundaryRepoImport',
+            data: {
+              expectedStem: serviceStem,
+              actualStem: repoStem,
+              importPath: sourceValue,
+            },
+          });
+        }
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'repoImportOutsideService',
+        data: {
+          importPath: sourceValue,
+          fileName: context.filename ?? 'unknown',
+        },
+      });
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration): void {
+        if (node.source.type === 'Literal' && typeof node.source.value === 'string') {
+          checkImport(node.source.value, node);
+        }
+      },
+      ImportExpression(node: TSESTree.ImportExpression): void {
+        if (node.source.type === 'Literal' && typeof node.source.value === 'string') {
+          checkImport(node.source.value, node);
+        }
+      },
+      ExportAllDeclaration(node: TSESTree.ExportAllDeclaration): void {
+        if (
+          node.source &&
+          node.source.type === 'Literal' &&
+          typeof node.source.value === 'string'
+        ) {
+          checkImport(node.source.value, node);
+        }
+      },
+      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration): void {
+        if (
+          node.source &&
+          node.source.type === 'Literal' &&
+          typeof node.source.value === 'string'
+        ) {
+          checkImport(node.source.value, node);
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/path-prefix-convention.ts
+++ b/packages/eslint-plugin/src/rules/path-prefix-convention.ts
@@ -1,0 +1,66 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/rule-factory';
+import { getRouteInfo } from '../utils/route-collector';
+
+export type MessageIds = 'pathPrefixMismatch';
+
+export type Options = [
+  {
+    prefixes?: string[];
+  },
+];
+
+export default createRule<Options, MessageIds>({
+  name: 'path-prefix-convention',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Enforce that route paths start with a required prefix (e.g., /api/).',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          prefixes: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'List of allowed prefixes that route paths must start with.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      pathPrefixMismatch:
+        "Route path '{{path}}' should start with one of the following prefixes: {{prefixes}}.",
+    },
+  },
+  defaultOptions: [{ prefixes: ['/api/'] }],
+  create(context, [options]) {
+    const allowedPrefixes = options.prefixes ?? ['/api/'];
+
+    return {
+      CallExpression(node: TSESTree.CallExpression): void {
+        const routeInfo = getRouteInfo(node);
+        if (!routeInfo) return;
+
+        const matchesPrefix = allowedPrefixes.some((prefix) =>
+          routeInfo.path.startsWith(prefix),
+        );
+
+        if (!matchesPrefix) {
+          context.report({
+            node,
+            messageId: 'pathPrefixMismatch',
+            data: {
+              path: routeInfo.path,
+              prefixes: allowedPrefixes.join(', '),
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/route-rules.test.ts
+++ b/packages/eslint-plugin/src/rules/route-rules.test.ts
@@ -1,0 +1,185 @@
+import { ESLint } from 'eslint';
+import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { routeStore } from '../utils/route-collector';
+
+const pluginPath = path.join(process.cwd(), 'dist', 'index.cjs');
+
+function createConfig(rules: Record<string, string | [string, ...unknown[]]>): string {
+  const rulesEntries = Object.entries(rules)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) {
+        return `"${k}": ${JSON.stringify(v)}`;
+      }
+      return `"${k}": "${v}"`;
+    })
+    .join(',\n    ');
+  return [
+    'const fossyl = require("' + pluginPath.replace(/\\/g, '/') + '").default;',
+    'module.exports = [{',
+    '  files: ["**/*.ts"],',
+    '  plugins: { fossyl },',
+    '  rules: {',
+    '    ' + rulesEntries,
+    '  },',
+    '  languageOptions: { ecmaVersion: 2020, sourceType: "module" },',
+    '}];',
+  ].join('\n');
+}
+
+async function lintInDir(
+  files: Record<string, string>,
+  rules: Record<string, string | [string, ...unknown[]]>,
+): Promise<Record<string, { ruleId: string | null; message: string }[]>> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fossyl-route-'));
+  try {
+    for (const [name, code] of Object.entries(files)) {
+      fs.writeFileSync(path.join(tmpDir, name), code);
+    }
+    fs.writeFileSync(path.join(tmpDir, 'eslint.config.cjs'), createConfig(rules));
+    const eslint = new ESLint({ cwd: tmpDir });
+    const results = await eslint.lintFiles(Object.keys(files));
+    const output: Record<string, { ruleId: string | null; message: string }[]> = {};
+    for (const result of results) {
+      const name = path.basename(result.filePath);
+      output[name] = result.messages.map((m) => ({
+        ruleId: m.ruleId,
+        message: m.message,
+      }));
+    }
+    return output;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+beforeEach(() => {
+  routeStore.reset();
+});
+
+describe('no-duplicate-routes', () => {
+  it('should allow unique routes across files', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/users");\n' +
+          'export const list = router.createEndpoint("/users").list({ handler: async () => ({ data: [], pagination: { page: 1, pageSize: 20, hasMore: false } }) });\n',
+        'posts.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/posts");\n' +
+          'export const list = router.createEndpoint("/posts").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/no-duplicate-routes': 'error' },
+    );
+
+    expect(results['users.route.ts']).toHaveLength(0);
+    expect(results['posts.route.ts']).toHaveLength(0);
+  });
+
+  it('should flag duplicate routes across files', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/users");\n' +
+          'export const get = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+        'duplicate.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/users");\n' +
+          'export const alsoGet = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/no-duplicate-routes': 'error' },
+    );
+
+    const dupErrors = results['duplicate.route.ts'] || [];
+    const hasError = dupErrors.some(
+      (e) => e.ruleId === 'fossyl/no-duplicate-routes',
+    );
+    expect(hasError).toBe(true);
+  });
+});
+
+describe('path-prefix-convention', () => {
+  it('should allow routes with valid prefix', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/api/users");\n' +
+          'export const get = router.createEndpoint("/api/users/:id").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/path-prefix-convention': 'warn' },
+    );
+    expect(results['users.route.ts']).toHaveLength(0);
+  });
+
+  it('should flag routes without /api/ prefix', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/users");\n' +
+          'export const get = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/path-prefix-convention': 'warn' },
+    );
+    const errors = results['users.route.ts'].filter(
+      (e) => e.ruleId === 'fossyl/path-prefix-convention',
+    );
+    expect(errors).toHaveLength(1);
+  });
+});
+
+describe('no-mixed-prefixes', () => {
+  it('should allow single prefix per file', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/users");\n' +
+          'export const get = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n' +
+          'export const list = router.createEndpoint("/users").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/no-mixed-prefixes': 'warn' },
+    );
+    const errors = results['users.route.ts'].filter(
+      (e) => e.ruleId === 'fossyl/no-mixed-prefixes',
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should flag multiple createRouter calls with different prefixes', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const userRouter = createRouter("/users");\n' +
+          'const adminRouter = createRouter("/admin");\n' +
+          'export const get = userRouter.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/no-mixed-prefixes': 'warn' },
+    );
+    const errors = results['users.route.ts'].filter(
+      (e) => e.ruleId === 'fossyl/no-mixed-prefixes',
+    );
+    expect(errors).toHaveLength(1);
+  });
+});
+
+describe('consistent-naming', () => {
+  it('should allow matching file name and prefix', async () => {
+    const results = await lintInDir(
+      {
+        'users.route.ts':
+          'import { createRouter } from "@fossyl/core";\n' +
+          'const router = createRouter("/users");\n' +
+          'export const list = router.createEndpoint("/users").get({ handler: async () => ({}) });\n',
+      },
+      { 'fossyl/consistent-naming': 'warn' },
+    );
+    expect(results['users.route.ts']).toHaveLength(0);
+  });
+});

--- a/packages/eslint-plugin/src/rules/route-rules.test.ts
+++ b/packages/eslint-plugin/src/rules/route-rules.test.ts
@@ -1,11 +1,11 @@
-import { ESLint } from 'eslint';
-import { describe, it, expect, beforeEach } from 'vitest';
-import path from 'node:path';
-import fs from 'node:fs';
-import os from 'node:os';
-import { routeStore } from '../utils/route-collector';
+import { ESLint } from "eslint";
+import { describe, it, expect, beforeEach } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { routeStore } from "../utils/route-collector";
 
-const pluginPath = path.join(process.cwd(), 'dist', 'index.cjs');
+const pluginPath = path.join(process.cwd(), "dist", "index.cjs");
 
 function createConfig(rules: Record<string, string | [string, ...unknown[]]>): string {
   const rulesEntries = Object.entries(rules)
@@ -15,30 +15,30 @@ function createConfig(rules: Record<string, string | [string, ...unknown[]]>): s
       }
       return `"${k}": "${v}"`;
     })
-    .join(',\n    ');
+    .join(",\n    ");
   return [
-    'const fossyl = require("' + pluginPath.replace(/\\/g, '/') + '").default;',
-    'module.exports = [{',
+    'const fossyl = require("' + pluginPath.replace(/\\/g, "/") + '").default;',
+    "module.exports = [{",
     '  files: ["**/*.ts"],',
-    '  plugins: { fossyl },',
-    '  rules: {',
-    '    ' + rulesEntries,
-    '  },',
+    "  plugins: { fossyl },",
+    "  rules: {",
+    "    " + rulesEntries,
+    "  },",
     '  languageOptions: { ecmaVersion: 2020, sourceType: "module" },',
-    '}];',
-  ].join('\n');
+    "}];",
+  ].join("\n");
 }
 
 async function lintInDir(
   files: Record<string, string>,
-  rules: Record<string, string | [string, ...unknown[]]>,
+  rules: Record<string, string | [string, ...unknown[]]>
 ): Promise<Record<string, { ruleId: string | null; message: string }[]>> {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fossyl-route-'));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fossyl-route-"));
   try {
     for (const [name, code] of Object.entries(files)) {
       fs.writeFileSync(path.join(tmpDir, name), code);
     }
-    fs.writeFileSync(path.join(tmpDir, 'eslint.config.cjs'), createConfig(rules));
+    fs.writeFileSync(path.join(tmpDir, "eslint.config.cjs"), createConfig(rules));
     const eslint = new ESLint({ cwd: tmpDir });
     const results = await eslint.lintFiles(Object.keys(files));
     const output: Record<string, { ruleId: string | null; message: string }[]> = {};
@@ -59,127 +59,121 @@ beforeEach(() => {
   routeStore.reset();
 });
 
-describe('no-duplicate-routes', () => {
-  it('should allow unique routes across files', async () => {
+describe("no-duplicate-routes", () => {
+  it("should allow unique routes across files", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/users");\n' +
-          'export const list = router.createEndpoint("/users").list({ handler: async () => ({ data: [], pagination: { page: 1, pageSize: 20, hasMore: false } }) });\n',
-        'posts.route.ts':
+          'export const list = router.createEndpoint("/users").paginate({ defaultPageSize: 20 }).get(({ pagination }) => async () => ({ data: [], pagination: { page: 1, pageSize: 20, hasMore: false } }));\n',
+        "posts.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/posts");\n' +
-          'export const list = router.createEndpoint("/posts").get({ handler: async () => ({}) });\n',
+          'export const list = router.createEndpoint("/posts").get(async () => ({}));\n',
       },
-      { 'fossyl/no-duplicate-routes': 'error' },
+      { "fossyl/no-duplicate-routes": "error" }
     );
 
-    expect(results['users.route.ts']).toHaveLength(0);
-    expect(results['posts.route.ts']).toHaveLength(0);
+    expect(results["users.route.ts"]).toHaveLength(0);
+    expect(results["posts.route.ts"]).toHaveLength(0);
   });
 
-  it('should flag duplicate routes across files', async () => {
+  it("should flag duplicate routes across files", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/users");\n' +
-          'export const get = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
-        'duplicate.route.ts':
+          'export const get = router.createEndpoint("/users/:id").get(({ url }) => async () => ({}));\n',
+        "duplicate.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/users");\n' +
-          'export const alsoGet = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+          'export const alsoGet = router.createEndpoint("/users/:id").get(({ url }) => async () => ({}));\n',
       },
-      { 'fossyl/no-duplicate-routes': 'error' },
+      { "fossyl/no-duplicate-routes": "error" }
     );
 
-    const dupErrors = results['duplicate.route.ts'] || [];
-    const hasError = dupErrors.some(
-      (e) => e.ruleId === 'fossyl/no-duplicate-routes',
-    );
+    const dupErrors = results["duplicate.route.ts"] || [];
+    const hasError = dupErrors.some((e) => e.ruleId === "fossyl/no-duplicate-routes");
     expect(hasError).toBe(true);
   });
 });
 
-describe('path-prefix-convention', () => {
-  it('should allow routes with valid prefix', async () => {
+describe("path-prefix-convention", () => {
+  it("should allow routes with valid prefix", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/api/users");\n' +
-          'export const get = router.createEndpoint("/api/users/:id").get({ handler: async () => ({}) });\n',
+          'export const get = router.createEndpoint("/api/users/:id").get(({ url }) => async () => ({}));\n',
       },
-      { 'fossyl/path-prefix-convention': 'warn' },
+      { "fossyl/path-prefix-convention": "warn" }
     );
-    expect(results['users.route.ts']).toHaveLength(0);
+    expect(results["users.route.ts"]).toHaveLength(0);
   });
 
-  it('should flag routes without /api/ prefix', async () => {
+  it("should flag routes without /api/ prefix", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/users");\n' +
-          'export const get = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+          'export const get = router.createEndpoint("/users/:id").get(({ url }) => async () => ({}));\n',
       },
-      { 'fossyl/path-prefix-convention': 'warn' },
+      { "fossyl/path-prefix-convention": "warn" }
     );
-    const errors = results['users.route.ts'].filter(
-      (e) => e.ruleId === 'fossyl/path-prefix-convention',
+    const errors = results["users.route.ts"].filter(
+      (e) => e.ruleId === "fossyl/path-prefix-convention"
     );
     expect(errors).toHaveLength(1);
   });
 });
 
-describe('no-mixed-prefixes', () => {
-  it('should allow single prefix per file', async () => {
+describe("no-mixed-prefixes", () => {
+  it("should allow single prefix per file", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/users");\n' +
-          'export const get = router.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n' +
-          'export const list = router.createEndpoint("/users").get({ handler: async () => ({}) });\n',
+          'export const get = router.createEndpoint("/users/:id").get(({ url }) => async () => ({}));\n' +
+          'export const list = router.createEndpoint("/users").get(async () => ({}));\n',
       },
-      { 'fossyl/no-mixed-prefixes': 'warn' },
+      { "fossyl/no-mixed-prefixes": "warn" }
     );
-    const errors = results['users.route.ts'].filter(
-      (e) => e.ruleId === 'fossyl/no-mixed-prefixes',
-    );
+    const errors = results["users.route.ts"].filter((e) => e.ruleId === "fossyl/no-mixed-prefixes");
     expect(errors).toHaveLength(0);
   });
 
-  it('should flag multiple createRouter calls with different prefixes', async () => {
+  it("should flag multiple createRouter calls with different prefixes", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const userRouter = createRouter("/users");\n' +
           'const adminRouter = createRouter("/admin");\n' +
-          'export const get = userRouter.createEndpoint("/users/:id").get({ handler: async () => ({}) });\n',
+          'export const get = userRouter.createEndpoint("/users/:id").get(({ url }) => async () => ({}));\n',
       },
-      { 'fossyl/no-mixed-prefixes': 'warn' },
+      { "fossyl/no-mixed-prefixes": "warn" }
     );
-    const errors = results['users.route.ts'].filter(
-      (e) => e.ruleId === 'fossyl/no-mixed-prefixes',
-    );
+    const errors = results["users.route.ts"].filter((e) => e.ruleId === "fossyl/no-mixed-prefixes");
     expect(errors).toHaveLength(1);
   });
 });
 
-describe('consistent-naming', () => {
-  it('should allow matching file name and prefix', async () => {
+describe("consistent-naming", () => {
+  it("should allow matching file name and prefix", async () => {
     const results = await lintInDir(
       {
-        'users.route.ts':
+        "users.route.ts":
           'import { createRouter } from "@fossyl/core";\n' +
           'const router = createRouter("/users");\n' +
-          'export const list = router.createEndpoint("/users").get({ handler: async () => ({}) });\n',
+          'export const list = router.createEndpoint("/users").get(async () => ({}));\n',
       },
-      { 'fossyl/consistent-naming': 'warn' },
+      { "fossyl/consistent-naming": "warn" }
     );
-    expect(results['users.route.ts']).toHaveLength(0);
+    expect(results["users.route.ts"]).toHaveLength(0);
   });
 });

--- a/packages/eslint-plugin/src/utils/route-collector.ts
+++ b/packages/eslint-plugin/src/utils/route-collector.ts
@@ -1,0 +1,167 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import path from 'node:path';
+
+export interface CollectedRoute {
+  filePath: string;
+  method: string;
+  fullPath: string;
+  basePrefix: string | null;
+  createEndpointNode: TSESTree.CallExpression;
+  createEndpointLine: number;
+}
+
+export interface FileRoutes {
+  filePath: string;
+  basePrefix: string | null;
+  routes: CollectedRoute[];
+}
+
+class RouteCollectorStore {
+  private routesByFile: Map<string, FileRoutes> = new Map();
+
+  reset(): void {
+    this.routesByFile.clear();
+  }
+
+  addRoute(filePath: string, route: CollectedRoute): void {
+    const existing = this.routesByFile.get(filePath);
+    if (existing) {
+      existing.routes.push(route);
+    } else {
+      this.routesByFile.set(filePath, {
+        filePath,
+        basePrefix: route.basePrefix,
+        routes: [route],
+      });
+    }
+  }
+
+  setBasePrefix(filePath: string, prefix: string): void {
+    const existing = this.routesByFile.get(filePath);
+    if (existing) {
+      existing.basePrefix = prefix;
+    } else {
+      this.routesByFile.set(filePath, {
+        filePath,
+        basePrefix: prefix,
+        routes: [],
+      });
+    }
+  }
+
+  getRoutesForFile(filePath: string): FileRoutes | undefined {
+    return this.routesByFile.get(filePath);
+  }
+
+  getAllRoutes(): FileRoutes[] {
+    return Array.from(this.routesByFile.values());
+  }
+
+  findDuplicates(): { method: string; path: string; occurrences: CollectedRoute[] }[] {
+    const routeMap = new Map<string, CollectedRoute[]>();
+    const duplicates: { method: string; path: string; occurrences: CollectedRoute[] }[] = [];
+
+    for (const fileRoutes of this.routesByFile.values()) {
+      for (const route of fileRoutes.routes) {
+        const key = `${route.method} ${route.fullPath}`;
+        const existing = routeMap.get(key);
+        if (existing) {
+          existing.push(route);
+        } else {
+          routeMap.set(key, [route]);
+        }
+      }
+    }
+
+    for (const [key, occurrences] of routeMap.entries()) {
+      if (occurrences.length > 1) {
+        const [method, ...pathParts] = key.split(' ');
+        duplicates.push({ method, path: pathParts.join(' '), occurrences });
+      }
+    }
+
+    return duplicates;
+  }
+}
+
+export const routeStore = new RouteCollectorStore();
+
+export interface RouteInfo {
+  method: string;
+  path: string;
+  node: TSESTree.CallExpression;
+}
+
+export function getRouteInfo(node: TSESTree.CallExpression): RouteInfo | null {
+  if (
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.property.type !== 'Identifier'
+  ) return null;
+
+  const validMethods = ['get', 'post', 'put', 'delete', 'list'];
+  if (!validMethods.includes(node.callee.property.name)) return null;
+
+  const object = node.callee.object;
+  if (
+    object.type !== 'CallExpression' ||
+    object.callee.type !== 'MemberExpression' ||
+    object.callee.property.type !== 'Identifier' ||
+    object.callee.property.name !== 'createEndpoint'
+  ) return null;
+
+  const arg = object.arguments[0];
+  if (!arg || arg.type !== 'Literal' || typeof arg.value !== 'string') return null;
+
+  return {
+    method: node.callee.property.name.toUpperCase(),
+    path: arg.value,
+    node,
+  };
+}
+
+export function getEndpointPath(node: TSESTree.CallExpression): string | null {
+  if (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'createEndpoint'
+  ) {
+    const arg = node.arguments[0];
+    if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
+      return arg.value;
+    }
+  }
+  return null;
+}
+
+export function getMethodFromEndpointCall(node: TSESTree.CallExpression): string | null {
+  if (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier'
+  ) {
+    const method = node.callee.property.name;
+    const validMethods = ['get', 'post', 'put', 'delete', 'list'];
+    if (validMethods.includes(method)) {
+      return method.toUpperCase();
+    }
+  }
+  return null;
+}
+
+export function getCreateRouterPrefix(node: TSESTree.CallExpression): string | null {
+  if (
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'createRouter'
+  ) {
+    const arg = node.arguments[0];
+    if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
+      return arg.value;
+    }
+  }
+  return null;
+}
+
+export function getRelativeFilePath(absolutePath: string): string {
+  const cwd = process.cwd();
+  const relative = path.relative(cwd, absolutePath);
+  return relative.replace(/\\/g, '/');
+}

--- a/packages/eslint-plugin/src/utils/route-collector.ts
+++ b/packages/eslint-plugin/src/utils/route-collector.ts
@@ -1,5 +1,5 @@
-import type { TSESTree } from '@typescript-eslint/utils';
-import path from 'node:path';
+import type { TSESTree } from "@typescript-eslint/utils";
+import path from "node:path";
 
 export interface CollectedRoute {
   filePath: string;
@@ -75,8 +75,8 @@ class RouteCollectorStore {
 
     for (const [key, occurrences] of routeMap.entries()) {
       if (occurrences.length > 1) {
-        const [method, ...pathParts] = key.split(' ');
-        duplicates.push({ method, path: pathParts.join(' '), occurrences });
+        const [method, ...pathParts] = key.split(" ");
+        duplicates.push({ method, path: pathParts.join(" "), occurrences });
       }
     }
 
@@ -93,67 +93,36 @@ export interface RouteInfo {
 }
 
 export function getRouteInfo(node: TSESTree.CallExpression): RouteInfo | null {
-  if (
-    node.callee.type !== 'MemberExpression' ||
-    node.callee.property.type !== 'Identifier'
-  ) return null;
+  if (node.callee.type !== "MemberExpression" || node.callee.property.type !== "Identifier")
+    return null;
 
-  const validMethods = ['get', 'post', 'put', 'delete', 'list'];
+  const validMethods = ["get", "post", "put", "delete"];
   if (!validMethods.includes(node.callee.property.name)) return null;
 
-  const object = node.callee.object;
-  if (
-    object.type !== 'CallExpression' ||
-    object.callee.type !== 'MemberExpression' ||
-    object.callee.property.type !== 'Identifier' ||
-    object.callee.property.name !== 'createEndpoint'
-  ) return null;
-
-  const arg = object.arguments[0];
-  if (!arg || arg.type !== 'Literal' || typeof arg.value !== 'string') return null;
-
-  return {
-    method: node.callee.property.name.toUpperCase(),
-    path: arg.value,
-    node,
-  };
-}
-
-export function getEndpointPath(node: TSESTree.CallExpression): string | null {
-  if (
-    node.callee.type === 'MemberExpression' &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === 'createEndpoint'
-  ) {
-    const arg = node.arguments[0];
-    if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
-      return arg.value;
+  let current = node.callee.object;
+  while (current.type === "CallExpression" && current.callee.type === "MemberExpression") {
+    if (
+      current.callee.property.type === "Identifier" &&
+      current.callee.property.name === "createEndpoint"
+    ) {
+      const arg = current.arguments[0];
+      if (!arg || arg.type !== "Literal" || typeof arg.value !== "string") return null;
+      return {
+        method: node.callee.property.name.toUpperCase(),
+        path: arg.value,
+        node,
+      };
     }
+    current = current.callee.object;
   }
-  return null;
-}
 
-export function getMethodFromEndpointCall(node: TSESTree.CallExpression): string | null {
-  if (
-    node.callee.type === 'MemberExpression' &&
-    node.callee.property.type === 'Identifier'
-  ) {
-    const method = node.callee.property.name;
-    const validMethods = ['get', 'post', 'put', 'delete', 'list'];
-    if (validMethods.includes(method)) {
-      return method.toUpperCase();
-    }
-  }
   return null;
 }
 
 export function getCreateRouterPrefix(node: TSESTree.CallExpression): string | null {
-  if (
-    node.callee.type === 'Identifier' &&
-    node.callee.name === 'createRouter'
-  ) {
+  if (node.callee.type === "Identifier" && node.callee.name === "createRouter") {
     const arg = node.arguments[0];
-    if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
+    if (arg && arg.type === "Literal" && typeof arg.value === "string") {
       return arg.value;
     }
   }
@@ -163,5 +132,5 @@ export function getCreateRouterPrefix(node: TSESTree.CallExpression): string | n
 export function getRelativeFilePath(absolutePath: string): string {
   const cwd = process.cwd();
   const relative = path.relative(cwd, absolutePath);
-  return relative.replace(/\\/g, '/');
+  return relative.replace(/\\/g, "/");
 }

--- a/packages/eslint-plugin/src/utils/rule-factory.ts
+++ b/packages/eslint-plugin/src/utils/rule-factory.ts
@@ -1,0 +1,6 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+export const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/YoyoSaur/fossyl/tree/main/packages/eslint-plugin/docs/rules/${name}.md`,
+);

--- a/packages/eslint-plugin/test-app/eslint.config.js
+++ b/packages/eslint-plugin/test-app/eslint.config.js
@@ -1,0 +1,26 @@
+import tsparser from '@typescript-eslint/parser';
+import fossyl from '../dist/index.js';
+
+export default [
+  {
+    ignores: ['**/dist/**'],
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+    },
+    plugins: { fossyl },
+    rules: {
+      'fossyl/no-repo-import-outside-service': 'error',
+      'fossyl/no-duplicate-routes': 'error',
+      'fossyl/path-prefix-convention': ['warn', { prefixes: ['/api/'] }],
+      'fossyl/consistent-naming': 'warn',
+      'fossyl/no-mixed-prefixes': 'warn',
+    },
+  },
+];

--- a/packages/eslint-plugin/test-app/package.json
+++ b/packages/eslint-plugin/test-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fossyl-eslint-test-app",
+  "private": true,
+  "type": "module",
+  "description": "Test fixture for eslint-plugin-fossyl rules",
+  "scripts": {
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@fossyl/core": "workspace:*",
+    "zod": "^3.23.0"
+  }
+}

--- a/packages/eslint-plugin/test-app/src/auth.ts
+++ b/packages/eslint-plugin/test-app/src/auth.ts
@@ -1,0 +1,9 @@
+import { authWrapper } from '@fossyl/core';
+
+export const authenticator = async (headers: Record<string, string>) => {
+  const userId = headers['x-user-id'];
+  if (!userId) {
+    throw new Error('Unauthorized');
+  }
+  return authWrapper({ userId });
+};

--- a/packages/eslint-plugin/test-app/src/features/todos/repo/todos.repo.ts
+++ b/packages/eslint-plugin/test-app/src/features/todos/repo/todos.repo.ts
@@ -1,0 +1,68 @@
+export interface Todo {
+  id: number;
+  title: string;
+  completed: boolean;
+  userId: string;
+  created_at: Date;
+}
+
+export interface TodoFilters {
+  completed?: boolean;
+  search?: string;
+}
+
+const todos: Map<number, Todo> = new Map();
+let nextId = 1;
+
+export async function findAll(
+  limit: number,
+  page: number,
+  filters: TodoFilters,
+): Promise<Todo[]> {
+  let all = Array.from(todos.values());
+  if (filters.completed !== undefined) {
+    all = all.filter((t) => t.completed === filters.completed);
+  }
+  if (filters.search) {
+    all = all.filter((t) => t.title.includes(filters.search!));
+  }
+  all.sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
+  const offset = (page - 1) * (limit - 1);
+  return all.slice(offset, offset + limit);
+}
+
+export async function findById(id: string): Promise<Todo | undefined> {
+  return todos.get(Number(id));
+}
+
+export async function create(data: { title: string; userId: string }): Promise<Todo> {
+  const todo: Todo = {
+    id: nextId++,
+    title: data.title,
+    completed: false,
+    userId: data.userId,
+    created_at: new Date(),
+  };
+  todos.set(todo.id, todo);
+  return todo;
+}
+
+export async function update(
+  id: string,
+  data: { title?: string; completed?: boolean },
+): Promise<Todo> {
+  const numId = Number(id);
+  const existing = todos.get(numId);
+  if (!existing) throw new Error('Not found');
+  const updated = { ...existing, ...data };
+  todos.set(numId, updated);
+  return updated;
+}
+
+export async function remove(id: string): Promise<void> {
+  todos.delete(Number(id));
+}
+
+export async function count(_filters: TodoFilters): Promise<number> {
+  return todos.size;
+}

--- a/packages/eslint-plugin/test-app/src/features/todos/routes/todos.route.ts
+++ b/packages/eslint-plugin/test-app/src/features/todos/routes/todos.route.ts
@@ -1,0 +1,59 @@
+import { createRouter } from "@fossyl/core";
+import type { PaginatedResponse } from "@fossyl/core";
+import * as todoService from "../services/todos.service";
+import { authenticator } from "../../../auth";
+
+const router = createRouter("/api/todos");
+
+export const listTodos = router.createEndpoint("/api/todos").list({
+  paginationConfig: { defaultPageSize: 20, maxPageSize: 100 },
+  handler: async ({ pagination }): Promise<PaginatedResponse<todoService.Todo>> => {
+    const result = await todoService.listTodos(pagination, {});
+    return {
+      data: result.data,
+      pagination: {
+        page: pagination.page,
+        pageSize: pagination.pageSize,
+        hasMore: result.hasMore,
+        total: result.total,
+      },
+    };
+  },
+});
+
+export const getTodo = router.createEndpoint("/api/todos/:id").get({
+  handler: async ({ url }, auth) => {
+    const todo = await todoService.getTodo(url.id);
+    return { typeName: "Todo" as const, ...todo };
+  },
+});
+
+const todoValidator = (data: unknown) => data as { title: string };
+
+export const createTodo = router.createEndpoint("/api/todos").post({
+  authenticator,
+  validator: todoValidator,
+  handler: async ({ url }, auth, body) => {
+    const todo = await todoService.createTodo(body.title);
+    return { typeName: "Todo" as const, ...todo };
+  },
+});
+
+export const updateTodo = router.createEndpoint("/api/todos/:id").put({
+  authenticator,
+  validator: todoValidator,
+  handler: async ({ url }, auth, body) => {
+    const todo = await todoService.updateTodo(url.id, body);
+    return { typeName: "Todo" as const, ...todo };
+  },
+});
+
+export const deleteTodo = router.createEndpoint("/api/todos/:id").delete({
+  authenticator,
+  handler: async ({ url }, auth) => {
+    await todoService.deleteTodo(url.id);
+    return { typeName: "DeleteResult" as const, id: url.id, deleted: true };
+  },
+});
+
+export default [listTodos, getTodo, createTodo, updateTodo, deleteTodo];

--- a/packages/eslint-plugin/test-app/src/features/todos/routes/todos.route.ts
+++ b/packages/eslint-plugin/test-app/src/features/todos/routes/todos.route.ts
@@ -5,9 +5,15 @@ import { authenticator } from "../../../auth";
 
 const router = createRouter("/api/todos");
 
-export const listTodos = router.createEndpoint("/api/todos").list({
-  paginationConfig: { defaultPageSize: 20, maxPageSize: 100 },
-  handler: async ({ pagination }): Promise<PaginatedResponse<todoService.Todo>> => {
+const todoValidator = (data: unknown) => data as { title: string };
+
+export const listTodos = router
+  .createEndpoint("/api/todos")
+  .paginate({
+    defaultPageSize: 20,
+    maxPageSize: 100,
+  })
+  .get(({ pagination }) => async (): Promise<PaginatedResponse<todoService.Todo>> => {
     const result = await todoService.listTodos(pagination, {});
     return {
       data: result.data,
@@ -18,42 +24,40 @@ export const listTodos = router.createEndpoint("/api/todos").list({
         total: result.total,
       },
     };
-  },
-});
+  });
 
-export const getTodo = router.createEndpoint("/api/todos/:id").get({
-  handler: async ({ url }, auth) => {
+export const getTodo = router
+  .createEndpoint("/api/todos/:id")
+  .authenticator(authenticator)
+  .get(({ url }) => (auth) => async () => {
     const todo = await todoService.getTodo(url.id);
     return { typeName: "Todo" as const, ...todo };
-  },
-});
+  });
 
-const todoValidator = (data: unknown) => data as { title: string };
-
-export const createTodo = router.createEndpoint("/api/todos").post({
-  authenticator,
-  validator: todoValidator,
-  handler: async ({ url }, auth, body) => {
+export const createTodo = router
+  .createEndpoint("/api/todos")
+  .authenticator(authenticator)
+  .validator(todoValidator)
+  .post((auth) => (body) => async () => {
     const todo = await todoService.createTodo(body.title);
     return { typeName: "Todo" as const, ...todo };
-  },
-});
+  });
 
-export const updateTodo = router.createEndpoint("/api/todos/:id").put({
-  authenticator,
-  validator: todoValidator,
-  handler: async ({ url }, auth, body) => {
+export const updateTodo = router
+  .createEndpoint("/api/todos/:id")
+  .authenticator(authenticator)
+  .validator(todoValidator)
+  .put(({ url }) => (auth) => (body) => async () => {
     const todo = await todoService.updateTodo(url.id, body);
     return { typeName: "Todo" as const, ...todo };
-  },
-});
+  });
 
-export const deleteTodo = router.createEndpoint("/api/todos/:id").delete({
-  authenticator,
-  handler: async ({ url }, auth) => {
+export const deleteTodo = router
+  .createEndpoint("/api/todos/:id")
+  .authenticator(authenticator)
+  .delete(({ url }) => (auth) => async () => {
     await todoService.deleteTodo(url.id);
     return { typeName: "DeleteResult" as const, id: url.id, deleted: true };
-  },
-});
+  });
 
 export default [listTodos, getTodo, createTodo, updateTodo, deleteTodo];

--- a/packages/eslint-plugin/test-app/src/features/todos/services/todos.service.ts
+++ b/packages/eslint-plugin/test-app/src/features/todos/services/todos.service.ts
@@ -1,0 +1,46 @@
+import type { PaginationParams } from '@fossyl/core';
+import * as todoRepo from '../repo/todos.repo';
+
+export type { Todo, TodoFilters } from '../repo/todos.repo';
+
+export interface TodoListResult {
+  data: todoRepo.Todo[];
+  hasMore: boolean;
+  total?: number;
+}
+
+export async function listTodos(
+  pagination: PaginationParams,
+  filters: todoRepo.TodoFilters,
+): Promise<TodoListResult> {
+  const results = await todoRepo.findAll(pagination.pageSize + 1, pagination.page, filters);
+  const hasMore = results.length > pagination.pageSize;
+  const data = hasMore ? results.slice(0, pagination.pageSize) : results;
+  const total = await todoRepo.count?.(filters);
+  return { data, hasMore, total };
+}
+
+export async function getTodo(id: string): Promise<todoRepo.Todo> {
+  const todo = await todoRepo.findById(id);
+  if (!todo) throw new Error('Todo not found');
+  return todo;
+}
+
+export async function createTodo(
+  title: string,
+): Promise<todoRepo.Todo> {
+  return todoRepo.create({ title, userId: '1' });
+}
+
+export async function updateTodo(
+  id: string,
+  data: { title?: string; completed?: boolean },
+): Promise<todoRepo.Todo> {
+  const existing = await todoRepo.findById(id);
+  if (!existing) throw new Error('Todo not found');
+  return todoRepo.update(id, data);
+}
+
+export async function deleteTodo(id: string): Promise<void> {
+  await todoRepo.remove(id);
+}

--- a/packages/eslint-plugin/test-app/src/features/users/repo/users.repo.ts
+++ b/packages/eslint-plugin/test-app/src/features/users/repo/users.repo.ts
@@ -1,0 +1,41 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  created_at: Date;
+}
+
+const users: Map<number, User> = new Map();
+let nextId = 1;
+
+export async function findById(id: string): Promise<User | undefined> {
+  return users.get(Number(id));
+}
+
+export async function findByEmail(email: string): Promise<User | undefined> {
+  return Array.from(users.values()).find((u) => u.email === email);
+}
+
+export async function create(data: { name: string; email: string }): Promise<User> {
+  const user: User = {
+    id: nextId++,
+    name: data.name,
+    email: data.email,
+    created_at: new Date(),
+  };
+  users.set(user.id, user);
+  return user;
+}
+
+export async function update(id: string, data: { name?: string }): Promise<User> {
+  const numId = Number(id);
+  const existing = users.get(numId);
+  if (!existing) throw new Error('Not found');
+  const updated = { ...existing, ...data };
+  users.set(numId, updated);
+  return updated;
+}
+
+export async function remove(id: string): Promise<void> {
+  users.delete(Number(id));
+}

--- a/packages/eslint-plugin/test-app/src/features/users/routes/users.route.ts
+++ b/packages/eslint-plugin/test-app/src/features/users/routes/users.route.ts
@@ -1,0 +1,44 @@
+import { createRouter } from '@fossyl/core';
+import * as userService from '../services/users.service';
+import { authenticator } from '../../../auth';
+import {
+  createUserValidator,
+  updateUserValidator,
+} from '../validators/users.validators';
+
+const router = createRouter('/api/users');
+
+export const getUser = router.createEndpoint('/api/users/:id').get({
+  handler: async ({ url }) => {
+    const user = await userService.getUser(url.id);
+    return { typeName: 'User' as const, ...user };
+  },
+});
+
+export const createUser = router.createEndpoint('/api/users').post({
+  authenticator,
+  validator: createUserValidator,
+  handler: async ({ url }, auth, body) => {
+    const user = await userService.createUser(body.name, body.email);
+    return { typeName: 'User' as const, ...user };
+  },
+});
+
+export const updateUser = router.createEndpoint('/api/users/:id').put({
+  authenticator,
+  validator: updateUserValidator,
+  handler: async ({ url }, auth, body) => {
+    const user = await userService.updateUser(url.id, body);
+    return { typeName: 'User' as const, ...user };
+  },
+});
+
+export const deleteUser = router.createEndpoint('/api/users/:id').delete({
+  authenticator,
+  handler: async ({ url }, auth) => {
+    await userService.deleteUser(url.id);
+    return { typeName: 'DeleteResult' as const, id: url.id, deleted: true };
+  },
+});
+
+export default [getUser, createUser, updateUser, deleteUser];

--- a/packages/eslint-plugin/test-app/src/features/users/routes/users.route.ts
+++ b/packages/eslint-plugin/test-app/src/features/users/routes/users.route.ts
@@ -1,44 +1,39 @@
-import { createRouter } from '@fossyl/core';
-import * as userService from '../services/users.service';
-import { authenticator } from '../../../auth';
-import {
-  createUserValidator,
-  updateUserValidator,
-} from '../validators/users.validators';
+import { createRouter } from "@fossyl/core";
+import * as userService from "../services/users.service";
+import { authenticator } from "../../../auth";
+import { createUserValidator, updateUserValidator } from "../validators/users.validators";
 
-const router = createRouter('/api/users');
+const router = createRouter("/api/users");
 
-export const getUser = router.createEndpoint('/api/users/:id').get({
-  handler: async ({ url }) => {
-    const user = await userService.getUser(url.id);
-    return { typeName: 'User' as const, ...user };
-  },
+export const getUser = router.createEndpoint("/api/users/:id").get(({ url }) => async () => {
+  const user = await userService.getUser(url.id);
+  return { typeName: "User" as const, ...user };
 });
 
-export const createUser = router.createEndpoint('/api/users').post({
-  authenticator,
-  validator: createUserValidator,
-  handler: async ({ url }, auth, body) => {
+export const createUser = router
+  .createEndpoint("/api/users")
+  .authenticator(authenticator)
+  .validator(createUserValidator)
+  .post((auth) => (body) => async () => {
     const user = await userService.createUser(body.name, body.email);
-    return { typeName: 'User' as const, ...user };
-  },
-});
+    return { typeName: "User" as const, ...user };
+  });
 
-export const updateUser = router.createEndpoint('/api/users/:id').put({
-  authenticator,
-  validator: updateUserValidator,
-  handler: async ({ url }, auth, body) => {
+export const updateUser = router
+  .createEndpoint("/api/users/:id")
+  .authenticator(authenticator)
+  .validator(updateUserValidator)
+  .put(({ url }) => (auth) => (body) => async () => {
     const user = await userService.updateUser(url.id, body);
-    return { typeName: 'User' as const, ...user };
-  },
-});
+    return { typeName: "User" as const, ...user };
+  });
 
-export const deleteUser = router.createEndpoint('/api/users/:id').delete({
-  authenticator,
-  handler: async ({ url }, auth) => {
+export const deleteUser = router
+  .createEndpoint("/api/users/:id")
+  .authenticator(authenticator)
+  .delete(({ url }) => (auth) => async () => {
     await userService.deleteUser(url.id);
-    return { typeName: 'DeleteResult' as const, id: url.id, deleted: true };
-  },
-});
+    return { typeName: "DeleteResult" as const, id: url.id, deleted: true };
+  });
 
 export default [getUser, createUser, updateUser, deleteUser];

--- a/packages/eslint-plugin/test-app/src/features/users/services/users.service.ts
+++ b/packages/eslint-plugin/test-app/src/features/users/services/users.service.ts
@@ -1,0 +1,27 @@
+import * as userRepo from '../repo/users.repo';
+
+export type { User } from '../repo/users.repo';
+
+export async function getUser(id: string): Promise<userRepo.User> {
+  const user = await userRepo.findById(id);
+  if (!user) throw new Error('User not found');
+  return user;
+}
+
+export async function createUser(
+  name: string,
+  email: string,
+): Promise<userRepo.User> {
+  return userRepo.create({ name, email });
+}
+
+export async function updateUser(
+  id: string,
+  data: { name?: string },
+): Promise<userRepo.User> {
+  return userRepo.update(id, data);
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  await userRepo.remove(id);
+}

--- a/packages/eslint-plugin/test-app/src/features/users/validators/users.validators.ts
+++ b/packages/eslint-plugin/test-app/src/features/users/validators/users.validators.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+const createUserSchema = z.object({
+  name: z.string().min(1).max(100),
+  email: z.string().email(),
+});
+
+const updateUserSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+});
+
+export const createUserValidator = (data: unknown) => createUserSchema.parse(data);
+
+export const updateUserValidator = (data: unknown) => updateUserSchema.parse(data);
+
+export const listUsersQueryValidator = z.object({
+  search: z.string().optional(),
+});

--- a/packages/eslint-plugin/test-app/src/index.ts
+++ b/packages/eslint-plugin/test-app/src/index.ts
@@ -1,0 +1,15 @@
+import { createRouter } from '@fossyl/core';
+import * as todosService from './features/todos/services/todos.service';
+import * as usersService from './features/users/services/users.service';
+
+const rootRouter = createRouter('/api');
+
+export const hello = rootRouter.createEndpoint('/api/hello').get({
+  handler: async () => ({ typeName: 'Hello' as const, message: 'world' }),
+});
+
+export const health = rootRouter.createEndpoint('/api/health').get({
+  handler: async () => ({ typeName: 'Health' as const, status: 'ok' }),
+});
+
+export default [hello, health, todosService, usersService];

--- a/packages/eslint-plugin/test-app/src/index.ts
+++ b/packages/eslint-plugin/test-app/src/index.ts
@@ -1,15 +1,15 @@
-import { createRouter } from '@fossyl/core';
-import * as todosService from './features/todos/services/todos.service';
-import * as usersService from './features/users/services/users.service';
+import { createRouter } from "@fossyl/core";
+import * as todosService from "./features/todos/services/todos.service";
+import * as usersService from "./features/users/services/users.service";
 
-const rootRouter = createRouter('/api');
+const rootRouter = createRouter("/api");
 
-export const hello = rootRouter.createEndpoint('/api/hello').get({
-  handler: async () => ({ typeName: 'Hello' as const, message: 'world' }),
-});
+export const hello = rootRouter
+  .createEndpoint("/api/hello")
+  .get(async () => ({ typeName: "Hello" as const, message: "world" }));
 
-export const health = rootRouter.createEndpoint('/api/health').get({
-  handler: async () => ({ typeName: 'Health' as const, status: 'ok' }),
-});
+export const health = rootRouter
+  .createEndpoint("/api/health")
+  .get(async () => ({ typeName: "Health" as const, status: "ok" }));
 
 export default [hello, health, todosService, usersService];

--- a/packages/eslint-plugin/test-app/src/violations/duplicate-routes.ts
+++ b/packages/eslint-plugin/test-app/src/violations/duplicate-routes.ts
@@ -1,0 +1,13 @@
+// VIOLATION: no-duplicate-routes
+// This file defines a route that already exists in todos.route.ts (GET /api/todos/:id).
+// Expected error: "Duplicate route: GET /api/todos/:id already defined at ..."
+
+import { createRouter } from '@fossyl/core';
+
+const router = createRouter('/api/todos');
+
+export const alsoGetTodo = router.createEndpoint('/api/todos/:id').get({
+  handler: async ({ url }) => {
+    return { typeName: 'Todo' as const, id: url.id, title: 'duplicate', completed: false };
+  },
+});

--- a/packages/eslint-plugin/test-app/src/violations/duplicate-routes.ts
+++ b/packages/eslint-plugin/test-app/src/violations/duplicate-routes.ts
@@ -2,12 +2,13 @@
 // This file defines a route that already exists in todos.route.ts (GET /api/todos/:id).
 // Expected error: "Duplicate route: GET /api/todos/:id already defined at ..."
 
-import { createRouter } from '@fossyl/core';
+import { createRouter } from "@fossyl/core";
 
-const router = createRouter('/api/todos');
+const router = createRouter("/api/todos");
 
-export const alsoGetTodo = router.createEndpoint('/api/todos/:id').get({
-  handler: async ({ url }) => {
-    return { typeName: 'Todo' as const, id: url.id, title: 'duplicate', completed: false };
-  },
-});
+export const alsoGetTodo = router.createEndpoint("/api/todos/:id").get(({ url }) => async () => ({
+  typeName: "Todo" as const,
+  id: url.id,
+  title: "duplicate",
+  completed: false,
+}));

--- a/packages/eslint-plugin/test-app/src/violations/mixed-prefixes.route.ts
+++ b/packages/eslint-plugin/test-app/src/violations/mixed-prefixes.route.ts
@@ -1,0 +1,20 @@
+// VIOLATION: no-mixed-prefixes
+// This file uses multiple createRouter() calls with different prefixes.
+// Expected warning: "File uses multiple router prefixes..."
+
+import { createRouter } from '@fossyl/core';
+
+const todosRouter = createRouter('/api/todos');
+const usersRouter = createRouter('/api/users');
+
+export const listTodos = todosRouter.createEndpoint('/api/todos').get({
+  handler: async () => {
+    return { typeName: 'TodoList' as const, todos: [] };
+  },
+});
+
+export const listUsers = usersRouter.createEndpoint('/api/users').get({
+  handler: async () => {
+    return { typeName: 'UserList' as const, users: [] };
+  },
+});

--- a/packages/eslint-plugin/test-app/src/violations/mixed-prefixes.route.ts
+++ b/packages/eslint-plugin/test-app/src/violations/mixed-prefixes.route.ts
@@ -2,19 +2,15 @@
 // This file uses multiple createRouter() calls with different prefixes.
 // Expected warning: "File uses multiple router prefixes..."
 
-import { createRouter } from '@fossyl/core';
+import { createRouter } from "@fossyl/core";
 
-const todosRouter = createRouter('/api/todos');
-const usersRouter = createRouter('/api/users');
+const todosRouter = createRouter("/api/todos");
+const usersRouter = createRouter("/api/users");
 
-export const listTodos = todosRouter.createEndpoint('/api/todos').get({
-  handler: async () => {
-    return { typeName: 'TodoList' as const, todos: [] };
-  },
-});
+export const listTodos = todosRouter
+  .createEndpoint("/api/todos")
+  .get(async () => ({ typeName: "TodoList" as const, todos: [] }));
 
-export const listUsers = usersRouter.createEndpoint('/api/users').get({
-  handler: async () => {
-    return { typeName: 'UserList' as const, users: [] };
-  },
-});
+export const listUsers = usersRouter
+  .createEndpoint("/api/users")
+  .get(async () => ({ typeName: "UserList" as const, users: [] }));

--- a/packages/eslint-plugin/test-app/src/violations/no-prefix.route.ts
+++ b/packages/eslint-plugin/test-app/src/violations/no-prefix.route.ts
@@ -1,0 +1,19 @@
+// VIOLATION: path-prefix-convention
+// Route paths must start with /api/ (the configured prefix).
+// Expected warning: "Route path '/todos' should start with one of the following prefixes: /api/."
+
+import { createRouter } from '@fossyl/core';
+
+const router = createRouter('/todos');
+
+export const listTodos = router.createEndpoint('/todos').get({
+  handler: async () => {
+    return { typeName: 'TodoList' as const, todos: [] };
+  },
+});
+
+export const getTodo = router.createEndpoint('/todos/:id').get({
+  handler: async ({ url }) => {
+    return { typeName: 'Todo' as const, id: url.id };
+  },
+});

--- a/packages/eslint-plugin/test-app/src/violations/no-prefix.route.ts
+++ b/packages/eslint-plugin/test-app/src/violations/no-prefix.route.ts
@@ -2,18 +2,14 @@
 // Route paths must start with /api/ (the configured prefix).
 // Expected warning: "Route path '/todos' should start with one of the following prefixes: /api/."
 
-import { createRouter } from '@fossyl/core';
+import { createRouter } from "@fossyl/core";
 
-const router = createRouter('/todos');
+const router = createRouter("/todos");
 
-export const listTodos = router.createEndpoint('/todos').get({
-  handler: async () => {
-    return { typeName: 'TodoList' as const, todos: [] };
-  },
-});
+export const listTodos = router
+  .createEndpoint("/todos")
+  .get(async () => ({ typeName: "TodoList" as const, todos: [] }));
 
-export const getTodo = router.createEndpoint('/todos/:id').get({
-  handler: async ({ url }) => {
-    return { typeName: 'Todo' as const, id: url.id };
-  },
-});
+export const getTodo = router
+  .createEndpoint("/todos/:id")
+  .get(({ url }) => async () => ({ typeName: "Todo" as const, id: url.id }));

--- a/packages/eslint-plugin/test-app/src/violations/plain-file-imports-repo.ts
+++ b/packages/eslint-plugin/test-app/src/violations/plain-file-imports-repo.ts
@@ -1,0 +1,15 @@
+// VIOLATION: no-repo-import-outside-service
+// Non-service files must NOT import .repo files.
+// Expected error: "Repository files (*.repo) can only be imported in service files (*.service)."
+
+import { Todo } from '../features/todos/repo/todos.repo';
+import { User } from '../features/users/repo/users.repo';
+
+export interface Report {
+  todo: Todo;
+  user: User;
+}
+
+export function generateReport(todo: Todo, user: User): Report {
+  return { todo, user };
+}

--- a/packages/eslint-plugin/test-app/src/violations/route-imports-repo.ts
+++ b/packages/eslint-plugin/test-app/src/violations/route-imports-repo.ts
@@ -1,0 +1,15 @@
+// VIOLATION: no-repo-import-outside-service
+// Route files must NOT import .repo files directly.
+// Expected error: "Repository files (*.repo) can only be imported in service files (*.service)."
+
+import * as todoRepo from '../features/todos/repo/todos.repo';
+import { createRouter } from '@fossyl/core';
+
+const router = createRouter('/api/violations');
+
+export const badRoute = router.createEndpoint('/api/violations/bad').get({
+  handler: async () => {
+    const todos = await todoRepo.findAll(10, 1, {});
+    return { typeName: 'Bad' as const, todos };
+  },
+});

--- a/packages/eslint-plugin/test-app/src/violations/things.route.ts
+++ b/packages/eslint-plugin/test-app/src/violations/things.route.ts
@@ -1,0 +1,13 @@
+// VIOLATION: consistent-naming
+// File is named 'things.route.ts' but the route prefix is '/api/gadgets'.
+// Expected warning: "Route prefix '/api/gadgets' does not match file name 'things.route.ts'..."
+
+import { createRouter } from '@fossyl/core';
+
+const router = createRouter('/api/gadgets');
+
+export const listGadgets = router.createEndpoint('/api/gadgets').get({
+  handler: async () => {
+    return { typeName: 'GadgetList' as const, gadgets: [] };
+  },
+});

--- a/packages/eslint-plugin/test-app/src/violations/things.route.ts
+++ b/packages/eslint-plugin/test-app/src/violations/things.route.ts
@@ -2,12 +2,10 @@
 // File is named 'things.route.ts' but the route prefix is '/api/gadgets'.
 // Expected warning: "Route prefix '/api/gadgets' does not match file name 'things.route.ts'..."
 
-import { createRouter } from '@fossyl/core';
+import { createRouter } from "@fossyl/core";
 
-const router = createRouter('/api/gadgets');
+const router = createRouter("/api/gadgets");
 
-export const listGadgets = router.createEndpoint('/api/gadgets').get({
-  handler: async () => {
-    return { typeName: 'GadgetList' as const, gadgets: [] };
-  },
-});
+export const listGadgets = router
+  .createEndpoint("/api/gadgets")
+  .get(async () => ({ typeName: "GadgetList" as const, gadgets: [] }));

--- a/packages/eslint-plugin/test-app/src/violations/things.service.ts
+++ b/packages/eslint-plugin/test-app/src/violations/things.service.ts
@@ -1,0 +1,10 @@
+// VIOLATION: no-repo-import-outside-service
+// Service files should only import repositories with matching names.
+// This file is 'things.service.ts' but imports 'todos.repo' (different boundary).
+// Expected error: "Service file imports repository from a different service boundary..."
+
+import { findAll } from '../features/todos/repo/todos.repo';
+
+export async function getAllThings() {
+  return findAll(10, 1, {});
+}

--- a/packages/eslint-plugin/test-app/src/violations/validator-imports-repo.ts
+++ b/packages/eslint-plugin/test-app/src/violations/validator-imports-repo.ts
@@ -1,0 +1,17 @@
+// VIOLATION: no-repo-import-outside-service
+// Validator files must NOT import .repo files directly.
+// Expected error: "Repository files (*.repo) can only be imported in service files (*.service)."
+
+import * as userRepo from '../features/users/repo/users.repo';
+import { z } from 'zod';
+
+// This is wrong - validators should not access repos
+export const badValidator = z.object({
+  email: z.string().email(),
+});
+
+// Using repo in a validator bypasses the service layer
+export async function checkEmailExists(email: string): Promise<boolean> {
+  const user = await userRepo.findByEmail(email);
+  return user !== undefined;
+}

--- a/packages/eslint-plugin/test-app/tsconfig.json
+++ b/packages/eslint-plugin/test-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,34 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/eslint-plugin:
+    dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.0.0
+        version: 8.54.0(eslint@9.39.2)(typescript@5.8.3)
+    devDependencies:
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.2
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.14)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.8.0
+        version: 5.8.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  packages/eslint-plugin/test-app:
+    dependencies:
+      '@fossyl/core':
+        specifier: workspace:*
+        version: link:../../core
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+
   packages/express:
     dependencies:
       '@types/express':
@@ -912,19 +940,9 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.53.2':
-    resolution: {integrity: sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.60.3':
     resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.53.2':
-    resolution: {integrity: sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.60.3':
@@ -932,19 +950,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.53.2':
-    resolution: {integrity: sha512-A6s4gJpomNBtJ2yioj8bflM2oogDwzUiMl2yNJ2v9E7++sHrSrsQ29fOfn5DM/iCzpWcebNYEdXpaK4tr2RhfQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.60.3':
     resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.53.2':
-    resolution: {integrity: sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.60.3':
@@ -952,19 +960,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.53.2':
-    resolution: {integrity: sha512-v0E9lJW8VsrwPux5Qe5CwmH/CF/2mQs6xU1MF3nmUxmZUCHazCjLgYvToOk+YuuUqLQBio1qkkREhxhc656ViA==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.60.3':
     resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.53.2':
-    resolution: {integrity: sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.60.3':
@@ -972,23 +970,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.2':
-    resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.53.2':
-    resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
@@ -996,35 +982,17 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.2':
-    resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.2':
-    resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  '@rollup/rollup-linux-loong64-gnu@4.53.2':
-    resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
@@ -1038,12 +1006,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.2':
-    resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
@@ -1056,23 +1018,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.2':
-    resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.53.2':
-    resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
@@ -1080,21 +1030,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.2':
-    resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.53.2':
-    resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1103,12 +1041,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.53.2':
-    resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
@@ -1121,29 +1053,14 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.53.2':
-    resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rollup/rollup-openharmony-arm64@4.60.3':
     resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.2':
-    resolution: {integrity: sha512-IlbHFYc/pQCgew/d5fslcy1KEaYVCJ44G8pajugd8VoOEI8ODhtb/j8XMhLpwHCMB3yk2J07ctup10gpw2nyMA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.60.3':
     resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.53.2':
-    resolution: {integrity: sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.60.3':
@@ -1151,18 +1068,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.53.2':
-    resolution: {integrity: sha512-S6YojNVrHybQis2lYov1sd+uj7K0Q05NxHcGktuMMdIQ2VixGwAfbJ23NnlvvVV1bdpR2m5MsNBViHJKcA4ADw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.60.3':
     resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.53.2':
-    resolution: {integrity: sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==}
     cpu: [x64]
     os: [win32]
 
@@ -1205,11 +1112,17 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1351,6 +1264,35 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
@@ -1420,6 +1362,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -1505,6 +1451,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1523,6 +1473,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1655,6 +1609,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1762,6 +1720,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -1874,6 +1835,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -2268,6 +2233,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -2346,6 +2314,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2776,6 +2747,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -2785,10 +2760,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -2992,11 +2963,6 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.53.2:
-    resolution: {integrity: sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3072,6 +3038,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3113,9 +3082,15 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -3146,6 +3121,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3181,6 +3159,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -3192,13 +3173,21 @@ packages:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -3275,9 +3264,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  ufo@1.6.1:
-    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -3430,6 +3416,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3478,6 +3469,34 @@ packages:
       vite:
         optional: true
 
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -3488,6 +3507,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4288,67 +4312,34 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.3
 
-  '@rollup/rollup-android-arm-eabi@4.53.2':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.60.3':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.53.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.3':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.2':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.53.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.3':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.2':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.53.2':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.53.2':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
@@ -4357,40 +4348,22 @@ snapshots:
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.53.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.53.2':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.53.2':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
@@ -4399,31 +4372,16 @@ snapshots:
   '@rollup/rollup-openbsd-x64@4.60.3':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.53.2':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.60.3':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.53.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.3':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.2':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.60.3':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.53.2':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.60.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.53.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.3':
@@ -4474,6 +4432,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 25.7.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.7.0
@@ -4481,6 +4444,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -4638,7 +4603,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.8.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -4661,6 +4626,48 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -4716,6 +4723,8 @@ snapshots:
   array-iterate@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -4867,9 +4876,9 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  bundle-require@5.1.0(esbuild@0.27.0):
+  bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
-      esbuild: 0.27.0
+      esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -4897,6 +4906,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4911,6 +4928,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -5012,6 +5031,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -5096,6 +5117,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -5203,7 +5226,7 @@ snapshots:
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -5288,6 +5311,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -5363,10 +5388,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -5409,7 +5430,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.53.2
+      rollup: 4.60.3
 
   flat-cache@4.0.1:
     dependencies:
@@ -5841,6 +5862,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -5914,6 +5937,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -6434,7 +6459,7 @@ snapshots:
       acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.1
+      ufo: 1.6.4
 
   mri@1.2.0: {}
 
@@ -6630,13 +6655,13 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -6892,34 +6917,6 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup@4.53.2:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.2
-      '@rollup/rollup-android-arm64': 4.53.2
-      '@rollup/rollup-darwin-arm64': 4.53.2
-      '@rollup/rollup-darwin-x64': 4.53.2
-      '@rollup/rollup-freebsd-arm64': 4.53.2
-      '@rollup/rollup-freebsd-x64': 4.53.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.2
-      '@rollup/rollup-linux-arm64-gnu': 4.53.2
-      '@rollup/rollup-linux-arm64-musl': 4.53.2
-      '@rollup/rollup-linux-loong64-gnu': 4.53.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.2
-      '@rollup/rollup-linux-riscv64-musl': 4.53.2
-      '@rollup/rollup-linux-s390x-gnu': 4.53.2
-      '@rollup/rollup-linux-x64-gnu': 4.53.2
-      '@rollup/rollup-linux-x64-musl': 4.53.2
-      '@rollup/rollup-openharmony-arm64': 4.53.2
-      '@rollup/rollup-win32-arm64-msvc': 4.53.2
-      '@rollup/rollup-win32-ia32-msvc': 4.53.2
-      '@rollup/rollup-win32-x64-gnu': 4.53.2
-      '@rollup/rollup-win32-x64-msvc': 4.53.2
-      fsevents: 2.3.3
-
   rollup@4.60.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -7079,6 +7076,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -7109,7 +7108,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -7141,6 +7144,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-js@1.1.21:
     dependencies:
@@ -7186,21 +7193,24 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.2: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tmp@0.2.5: {}
 
@@ -7227,22 +7237,22 @@ snapshots:
 
   tsup@8.5.1(postcss@8.5.14)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.0)
+      bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.0
+      esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.21.0)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.53.2
+      rollup: 4.60.3
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.14
@@ -7272,8 +7282,6 @@ snapshots:
   typescript@5.8.3: {}
 
   typescript@6.0.3: {}
-
-  ufo@1.6.1: {}
 
   ufo@1.6.4: {}
 
@@ -7391,6 +7399,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
@@ -7409,6 +7438,48 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.3(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 25.7.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
@@ -7416,6 +7487,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/*'
   - 'examples/*'
+  - 'packages/eslint-plugin/test-app'
 allowBuilds:
   esbuild: false
   sharp: false


### PR DESCRIPTION
Summary
Adapted the ESLint plugin for the @fossyl/core chain API rewrite. The old overload-based config object pattern (.get({ handler: fn }), .post({ authenticator, validator, handler: fn }), .list({ paginationConfig, handler: fn })) is replaced by the type-state chain builder (.authenticator(fn).validator(fn).post(handler), .paginate(cfg).get(handler), etc.).
Changes
route-collector.ts
- Rewrote getRouteInfo to walk the callee chain backward until it finds createEndpoint, supporting any chain depth (.paginate().get(), .authenticator().validator().post(), .noTransaction().get(), etc.)
- Removed 'list' from valid methods — no longer exists in the chain API
- Removed unused getEndpointPath and getMethodFromEndpointCall helper functions
Test fixtures (unit tests, test-app routes, violations)
- Converted all route definitions across test-app/src/ and route-rules.test.ts from old config-object pattern to chain API with correct curried handler signatures
- Updated integration test expected violation count for mixed-prefixes.route.ts (3→4) — .paginate().get() is now correctly detected as GET, catching a duplicate that was previously missed
Documentation (AGENTS.md)
- Added "Chain API Handler Shapes" section with handler signature table for all 8 layer combinations, 4 rules, and 5 examples covering the curry pattern
